### PR TITLE
chore: Add Spring RTS Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ If you are also interested in clones and similar games (0 A.D. etc.), take a loo
 - [Race into Space](https://github.com/raceintospace/raceintospace) - Version of Interplay's Buzz Aldrin's Race into Space.
 - [Return To The Roots](https://github.com/Return-To-The-Roots/s25client) - Settlers II remake written in C++.
 - [Sourcehold](https://github.com/sourcehold/Sourcehold) - Implementation of Stronghold by Firefly Studios.
+- [Spring RTS](https://springrts.com) - A real-time 3D strategy engine intended to bring the gameplay experience of Total Annihilation into three dimensions.
 - [Stone Kingdoms](https://gitlab.com/stone-kingdoms/stone-kingdoms) - A real-time strategy game made with LÖVE based on the original Stronghold by Firefly studios.
 - [VanillaConquer](https://github.com/TheAssemblyArmada/Vanilla-Conquer/) - Command and Conquer and Red Alert original release source port based on the remaster source code drop.
 - [VCMI](https://github.com/vcmi/vcmi) - Engine for Heroes of Might and Magic III.


### PR DESCRIPTION
Wanted to add the Spring RTS Engine to the list.  Open source 3D RTS engine that supports Windows/Linux/Mac.  Has several mods and games built for the engine.

GitHub link: [Spring Project](https://github.com/spring/spring)
